### PR TITLE
Fixes dependency issues

### DIFF
--- a/mbsy.gemspec
+++ b/mbsy.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 1.9.2"
 
-  s.add_runtime_dependency('httparty', '~> 0.8.3')
-  s.add_runtime_dependency('json', '~> 1.7.3')
+  s.add_runtime_dependency('httparty', '>= 0.8.3')
+  s.add_runtime_dependency('json', '>= 1.7.3')
 
   s.add_development_dependency('rake', '~> 0.9.2')
   s.add_development_dependency('rspec', '~> 2.7.0')


### PR DESCRIPTION
Adds 'httparty' and 'json' in as runtime dependencies since those libraries are required in order to use the gem.  Relaxes version requirements for those libraries as well.
