### PR TITLE
Use CGI::escape rather than URI.escape for query params

### DIFF
--- a/lib/mbsy.rb
+++ b/lib/mbsy.rb
@@ -1,3 +1,4 @@
+require 'cgi'
 require 'httparty'
 require 'json'
 require 'mbsy/resources/base'

--- a/lib/mbsy/util/single_sign_on.rb
+++ b/lib/mbsy/util/single_sign_on.rb
@@ -12,7 +12,7 @@ module Mbsy
       raise ArgumentError, "key :email is required" if options[:email].blank?
       raise ArgumentError, ":method must be either :login or :logout" unless %w(login logout).include?( options[:method].to_s )
       signature = Digest::SHA1.hexdigest( options[:api_key] + options[:email] )
-      %Q|<img src="https://#{Mbsy.user_name}.getambassador.com/sso/#{options[:method]}/?token=#{options[:token]}&email=#{URI.escape(options[:email])}&signature=#{signature}" style="border: none; visibility: hidden" alt="" />|
+      %Q|<img src="https://#{Mbsy.user_name}.getambassador.com/sso/#{options[:method]}/?token=#{options[:token]}&email=#{CGI::escape(options[:email])}&signature=#{signature}" style="border: none; visibility: hidden" alt="" />|
     end
 
 


### PR DESCRIPTION
Explanation:

While SSO worked fine for "normal" email addresses, my usual workflow
involves using the `+` sign to generate reusable email addresses for
manual testing purposes (e.g., "myemail+0001@gmail.com",
"myemail+0002@gmail.com", etc.).

Because the `+` symbol represents a space character (" ") within query
parameters, Ambassador's SSO is unable to associate these email
addresses with their respective accounts.

This means users whose email addresses contain the `+` sign cannot log
into their Ambassador portals via SSO. Ambassador otherwise appears to
support email addresses containing the symbol.

**CGI::escape** properly converts email addresses to their url encoded form,
but **URI.escape** leaves them as-is:

`CGI::escape('abc+123@gmail.com') => "abc%2B123%40gmail.com"`
`URI.escape('abc+123@gmail.com') => "abc+123@gmail.com"`

See these "fun" links:
- http://stackoverflow.com/a/13059657/983049
- http://stackoverflow.com/questions/1005676/urls-and-plus-signs