### PR TITLE
Add option for custom domain to single sign on

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,9 @@ doc
 
 # jeweler generated
 pkg
+*.gem
 
-# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
+# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore:
 #
 # * Create a file at ~/.gitignore
 # * Include files you want ignored

--- a/lib/mbsy/util/single_sign_on.rb
+++ b/lib/mbsy/util/single_sign_on.rb
@@ -12,7 +12,8 @@ module Mbsy
       raise ArgumentError, "key :email is required" if options[:email].blank?
       raise ArgumentError, ":method must be either :login or :logout" unless %w(login logout).include?( options[:method].to_s )
       signature = Digest::SHA1.hexdigest( options[:api_key] + options[:email] )
-      %Q|<img src="https://#{Mbsy.user_name}.getambassador.com/sso/#{options[:method]}/?token=#{options[:token]}&email=#{CGI::escape(options[:email])}&signature=#{signature}" style="border: none; visibility: hidden" alt="" />|
+      domain = if options[:domain].blank? then "#{Mbsy.user_name}.getambassador.com" else options[:domain] end
+      %Q|<img src="https://#{domain}/sso/#{options[:method]}/?token=#{options[:token]}&email=#{CGI::escape(options[:email])}&signature=#{signature}" style="border: none; visibility: hidden" alt="" />|
     end
 
 

--- a/lib/mbsy/version.rb
+++ b/lib/mbsy/version.rb
@@ -1,3 +1,3 @@
 module Mbsy
-  VERSION = '2.0.0'
+  VERSION = '2.0.1'
 end

--- a/lib/mbsy/version.rb
+++ b/lib/mbsy/version.rb
@@ -1,3 +1,3 @@
 module Mbsy
-  VERSION = '2.0.1'
+  VERSION = '2.1.0'
 end


### PR DESCRIPTION
- Adds `domain` argument to `Mbsy.SingleSignOn.embed_html`
- Falls back to existing `username.getambassador.com` behavior

Requested in https://github.com/GetAmbassador/mbsy/issues/19.