### PR TITLE
Update json gem: 2.0.3 -> 2.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    mbsy (1.1.4)
+    mbsy (2.1.0)
       httparty (= 0.14.0)
-      json (= 2.0.3)
+      json (= 2.3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -33,7 +33,7 @@ GEM
     httparty (0.14.0)
       multi_xml (>= 0.5.2)
     i18n (0.8.1)
-    json (2.0.3)
+    json (2.3.0)
     minitest (5.10.1)
     multi_xml (0.6.0)
     public_suffix (2.0.5)

--- a/mbsy.gemspec
+++ b/mbsy.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 1.9.2"
 
   s.add_runtime_dependency('httparty', '0.14.0')
-  s.add_runtime_dependency('json', '2.0.3')
+  s.add_runtime_dependency('json', '2.3.0')
 
   s.add_development_dependency('rake', '12.0.0')
   s.add_development_dependency('rspec', '3.5.0')


### PR DESCRIPTION
When running `mbusy` on ruby 2.7, the `json` gem yields recurrent warnings about a deprecated feature of the language:

```
lib/json/common.rb:156: warning: Using the last argument as keyword parameters is deprecated
```